### PR TITLE
Add Describe command for schema inspection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,28 @@ jwalk obj{8} / $ ls
   engine: 'node >= 0.8.x' }
 ```
 
+### Describe
+
+Show the schema of the given node.
+
+```
+jwalk obj{8} / $ ll
+/
+  name string(5) "jwalk"
+  version string(5) "0.0.4"
+  description string(27) "command-line json inspector"
+  preferGlobal string(4) "true"
+  repositories object 
+  bin object 
+  dependencies object 
+  engine string(13) "node >= 0.8.x"
+jwalk obj{8} / $ ll repositories
+/repositories/
+  type string(3) "git"
+  url string(31) "http://github.com/nkohari/jwalk"
+```
+
+
 ### Change Directory
 
 Allows navigation through the JSON tree. Note 'cd' does support autocomplete by pressing the tab key.

--- a/src/commands/Describe.coffee
+++ b/src/commands/Describe.coffee
@@ -1,0 +1,63 @@
+_ = require 'underscore'
+Command = require './Command'
+
+class Describe extends Command
+
+	help: ->
+		'examines the schema of an object node'
+
+	autocomplete: (context, str, callback) ->
+		return super unless _.isObject(context.pointer)
+		keys    = _.keys(context.pointer)
+		matches = _.filter keys, (key) -> key.indexOf(str) == 0
+		results = if matches.length > 0 then matches else keys
+		callback null, [results, str]
+
+	run: (context, args, callback) ->
+		
+		root = context.pointer
+		path = '/' + context.path.join('/')
+		try
+			subpath = if args? and args[0]? then args[0] else ''
+			if subpath.length > 0
+				for key in subpath.split('/')
+					root = root[key]
+					path += key + '/'
+		catch error
+			console.log "Not an object".red
+			console.log error
+			callback()
+			return
+
+		console.log path
+
+		unless _.isObject(root)
+			console.log "Not an object".red
+			callback()
+			return
+
+		typedesc = (key, obj) ->
+			rslt = ""
+			summary = ""
+			if _.isArray(obj)
+				rslt = "array(#{obj.length})"
+			else if _.isNumber(obj)
+				rslt = "number"
+				summary = obj.toString().red
+			else if _.isString(obj)
+				rslt = "string(#{obj.length})"
+				sz = 80
+				summary = if obj then '"' + obj.substring(0, sz) + '"' else ''
+				summary += '..' if obj.length > sz
+			else
+				rslt = typeof(obj)
+			rslt = rslt.cyan + ' ' + summary.green
+
+		for key in _.keys(root)
+			do (key) ->
+				value = root[key]
+				console.log ' ', key, typedesc(key, value)
+
+		callback()
+
+module.exports = Describe

--- a/src/commands/index.coffee
+++ b/src/commands/index.coffee
@@ -3,6 +3,7 @@ ClearScreen = require './ClearScreen'
 ExitProcess = require './ExitProcess'
 Help        = require './Help'
 ShowKeys    = require './ShowKeys'
+Describe    = require './Describe'
 Inspect     = require './Inspect'
 
 commands =
@@ -11,6 +12,7 @@ commands =
 	cls:   new ClearScreen()
 	exit:  new ExitProcess()
 	keys:  new ShowKeys()
+	ll:    new Describe()
 	ls:    new Inspect()
 	quit:  new ExitProcess()
 


### PR DESCRIPTION
Added a `ll` command to inspect the schema of the specified node.
It also gives a preview of the value each child holds. For strings only the first 80 characters are shown, so the screen won't be messed up when dealing with extremely long strings.
